### PR TITLE
ci: skip Claude Code Review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,9 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot PRs - they don't have access to secrets
+    # Only run Claude Code Review on PRs from repository owner/collaborators
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     
     runs-on: ubuntu-latest
     permissions:
@@ -51,4 +49,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-


### PR DESCRIPTION
Dependabot PRs don't have access to repository secrets, causing Claude Code Review to fail when looking for model credentials.

Changes:
- Add condition to skip PRs from 'dependabot[bot]' user
- Claude will now only run on PRs from repository owner/collaborators
- Removes noise from failed CI runs on Dependabot PRs

This keeps Claude Code Review running on your own work while avoiding authentication errors on automated dependency updates.