### PR TITLE
update tags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ enum Commands {
         /// Path to project (defaults to current directory)
         #[arg(default_value = ".")]
         path: String,
-        /// Extra tags to apply to newly created sidecar files
+        /// Extra tags to apply to newly created sidecar files (repeatable, deduplicated)
         #[arg(short = 't', long = "tag", action = clap::ArgAction::Append)]
         tags: Vec<String>,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,9 @@ enum Commands {
         /// Path to project (defaults to current directory)
         #[arg(default_value = ".")]
         path: String,
+        /// Extra tags to apply to newly created sidecar files
+        #[arg(short = 't', long = "tag", action = clap::ArgAction::Append)]
+        tags: Vec<String>,
     },
     /// Validate YAML frontmatter in all sidecar files
     Lint {
@@ -240,8 +243,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                 interactive,
             )?;
         }
-        Commands::Update { path } => {
-            cli::update::handle_update(&path)?;
+        Commands::Update { path, tags } => {
+            cli::update::handle_update(&path, &tags)?;
         }
         Commands::Lint { path } => {
             cli::lint::handle_lint(&path)?;


### PR DESCRIPTION
  src/main.rs:
  - Added tags: Vec<String> field to Commands::Update with -t/--tag flag using ArgAction::Append
  - Updated the match arm to destructure and pass tags to handle_update

  src/cli/update.rs:
  - handle_update — added extra_tags: &[String] parameter, threaded to process_media_file and print_update_summary
  - process_media_file — added extra_tags: &[String] parameter, threaded to generate_sidecar_content
  - generate_sidecar_content — added extra_tags: &[String] parameter, appends extra tags with dedup after existing tag-building logic
  - print_update_summary — added extra_tags: &[String] parameter, prints "Extra tags: ..." line when non-empty

  Usage: zim update --tag jazz --tag ambient ./mixes